### PR TITLE
Use a subset of default notification events (#1)

### DIFF
--- a/gong-notifier-base/src/main/java/ch/adnovum/gong/notifier/PluginSettingsBase.java
+++ b/gong-notifier-base/src/main/java/ch/adnovum/gong/notifier/PluginSettingsBase.java
@@ -1,7 +1,10 @@
 package ch.adnovum.gong.notifier;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import ch.adnovum.gong.notifier.go.api.SettingsField;
 
@@ -11,6 +14,7 @@ public class PluginSettingsBase {
 	private static final String DEFAULT_SERVER_DISPLAY_URL = "https://localhost:8154/go";
 	private static final String DEFAULT_REST_USER = null;
 	private static final String DEFAULT_REST_PASSWORD = null;
+	private static final String DEFAULT_EVENTS = "broken, fixed, failed";
 	
 	public static final Map<String, SettingsField> BASE_FIELD_CONFIG = new HashMap<>();
 	static {
@@ -18,12 +22,15 @@ public class PluginSettingsBase {
 		BASE_FIELD_CONFIG.put("serverDisplayUrl", new SettingsField("Server Display URL", DEFAULT_SERVER_DISPLAY_URL, false, false, 0));
 		BASE_FIELD_CONFIG.put("restUser", new SettingsField("Rest User", DEFAULT_REST_USER, false, false, 0));
 		BASE_FIELD_CONFIG.put("restPassword", new SettingsField("Rest Password", DEFAULT_REST_PASSWORD, false, true, 0));
+		BASE_FIELD_CONFIG.put("defaultEvents", new SettingsField("Default notification events", DEFAULT_EVENTS, false, false,
+				0));
 	}
 
 	private String serverUrl = DEFAULT_SERVER_URL;
 	private String serverDisplayUrl = DEFAULT_SERVER_DISPLAY_URL;
 	private String restUser = DEFAULT_REST_USER;
 	private String restPassword = DEFAULT_REST_PASSWORD;
+	private String defaultEvents = DEFAULT_EVENTS;
 
 	public String getServerDisplayUrl() {
 		return valueOrDefault(serverDisplayUrl, DEFAULT_SERVER_DISPLAY_URL);
@@ -55,6 +62,18 @@ public class PluginSettingsBase {
 
 	public void setRestPassword(String restPassword) {
 		this.restPassword = restPassword;
+	}
+
+	public String getDefaultEvents() {
+		return valueOrDefault(defaultEvents, DEFAULT_EVENTS);
+	}
+
+	public Set<String> getDefaultEventsSet() {
+		return new HashSet<>(Arrays.asList(getDefaultEvents().split("\\s*,\\s*")));
+	}
+
+	public void setDefaultEvents(String defaultEvents) {
+		this.defaultEvents = defaultEvents;
 	}
 
 	private static String valueOrDefault(String value, String defaultValue) {

--- a/gong-notifier-base/src/main/java/ch/adnovum/gong/notifier/go/api/GoServerApi.java
+++ b/gong-notifier-base/src/main/java/ch/adnovum/gong/notifier/go/api/GoServerApi.java
@@ -55,7 +55,7 @@ public class GoServerApi {
 				return Optional.of(t);
 			}
 		}
-		catch (IOException e) {
+		catch (Exception e) {
 			LOGGER.error("Error fetching " + url + ":", e);
 			return Optional.empty();
 		}

--- a/gong-notifier-base/src/main/resources/plugin-settings-base.template.html
+++ b/gong-notifier-base/src/main/resources/plugin-settings-base.template.html
@@ -22,6 +22,11 @@
     <input id="gong-rest-pwd" type="password" ng-model="restPassword"/>
     <span class="form_error" ng-show="GOINPUTNAME[restPassword].$error.server">{{ GOINPUTNAME[restPassword].$error.server }}</span>
 </div>
+<div class="form_item_block">
+    <label>Default events to notify:</label>
+    <input id="default-events" type="text" ng-model="defaultEvents" placeholder="fixed, broken, failed"/>
+    <span class="form_error" ng-show="GOINPUTNAME[defaultEvents].$error.server">{{ GOINPUTNAME[defaultEvents].$error.server }}</span>
+</div>
 <!-- Not really useful because the ajax request always includes the user's session cookie (no way not to) so can't verify authorization -->
 <!--
 <button class="check_connection submit button MB_focusable"

--- a/gong-notifier-email/src/main/java/ch/adnovum/gong/notifier/email/EmailNotificationListener.java
+++ b/gong-notifier-email/src/main/java/ch/adnovum/gong/notifier/email/EmailNotificationListener.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import ch.adnovum.gong.notifier.ConfigurableNotificationListener;
 import ch.adnovum.gong.notifier.PipelineInfoProvider;
@@ -30,8 +31,9 @@ public class EmailNotificationListener extends ConfigurableNotificationListener 
 	private ModificationListGenerator modListGenerator;
 
 	public EmailNotificationListener(PipelineInfoProvider pipelineInfo, EmailSender emailSender, String senderEmail,
-			String subjectTemplate, String bodyTemplate, String serverDisplayUrl, ModificationListGenerator modListGenerator) {
-		super(pipelineInfo, EMAIL_ENV_VARIABLE, TARGET_SUFFIX, EVENTS_SUFFIX);
+			String subjectTemplate, String bodyTemplate, String serverDisplayUrl, Set<String> defaultEvents,
+			ModificationListGenerator modListGenerator) {
+		super(pipelineInfo, EMAIL_ENV_VARIABLE, TARGET_SUFFIX, EVENTS_SUFFIX, defaultEvents);
 
 		this.emailSender = emailSender;
 		this.senderEmail = senderEmail;
@@ -44,7 +46,8 @@ public class EmailNotificationListener extends ConfigurableNotificationListener 
 	public EmailNotificationListener(PipelineInfoProvider pipelineInfo, EmailSender emailSender,
 			PluginSettings settings) {
 		this(pipelineInfo, emailSender, settings.getSenderEmail(), settings.getSubjectTemplate(), settings.getBodyTemplate(),
-				settings.getServerDisplayUrl(), new ModificationListGenerator(settings.getTimezone(), true));
+				settings.getServerDisplayUrl(), settings.getDefaultEventsSet(),
+				new ModificationListGenerator(settings.getTimezone(), true));
 	}
 
 	@Override


### PR DESCRIPTION
Only use broken, failed, and fixed by default.
This default can be changed in the plugin config.